### PR TITLE
Auto Neuralynx constructor

### DIFF
--- a/brody_lab_to_nwb/utils.py
+++ b/brody_lab_to_nwb/utils.py
@@ -1,0 +1,28 @@
+"""Authors: Cody Baker."""
+from typing import Union
+from pathlib import Path
+from natsort import natsorted
+
+from spikeextractors import NeuralynxRecordingExtractor, MultiRecordingChannelExtractor
+
+
+PathType = Union[str, Path]
+
+
+def make_nlx_extractor(folder_path: PathType):
+    """
+    Auxiliary function for robust loading of Neuralynx .ncs files from common folder_path.
+
+    Parameters
+    ----------
+    folder_path : PathType
+        Path to the folder containing the .ncs files to be loaded.
+    """
+    neuralynx_files = natsorted([str(x) for x in Path(folder_path).iterdir() if ".ncs" in x.suffixes])
+    extractors = [NeuralynxRecordingExtractor(filename=filename, seg_index=0) for filename in neuralynx_files]
+    gains = [extractor.get_channel_gains()[0] for extractor in extractors]
+    for extractor in extractors:
+        extractor.clear_channel_gains()
+    recording_extractor = MultiRecordingChannelExtractor(extractors)
+    recording_extractor.set_channel_gains(gains=gains)
+    return recording_extractor

--- a/notebooks/neuralynx_spikeinterface_pipeline.ipynb
+++ b/notebooks/neuralynx_spikeinterface_pipeline.ipynb
@@ -24,6 +24,8 @@
     "import spikecomparison as sc\n",
     "import spikewidgets as sw\n",
     "\n",
+    "from brody_lab_to_nwb.utils import make_nlx_extractor\n",
+    "\n",
     "%matplotlib notebook"
    ]
   },
@@ -89,24 +91,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from typing import Union\n",
-    "from re import search\n",
-    "\n",
-    "def get_sorted_ncs_files(folder_path: Union[str, Path]):\n",
-    "    neuralynx_files = [x for x in Path(folder_path).iterdir() if \".ncs\" in x.suffixes]\n",
-    "    file_nums = [int(search(r\"\\d+$\", filename.stem)[0]) for filename in neuralynx_files]\n",
-    "    sort_idx = np.argsort(file_nums)\n",
-    "    return (np.array(neuralynx_files)[sort_idx]).tolist()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ncs_files = get_sorted_ncs_files(folder_path=neuralynx_folder_path)[:4] # the :4 subsetting is currently for Windows testing\n",
-    "recording_ap = se.MultiRecordingChannelExtractor([se.NeuralynxRecordingExtractor(filename=x) for x in ncs_files])\n",
+    "recording_ap = make_nlx_extractor(folder_path=neuralynx_folder_path)\n",
     "\n",
     "if stub_test:\n",
     "    recording_ap = se.SubRecordingExtractor(recording_ap, end_frame=int(nsec_stub*recording_ap.get_sampling_frequency()))"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ isodate==0.6.0
 git+https://github.com/catalystneuro/nwb-conversion-tools@19defdd7550653a710bd7c9a09b101b91375406d
 jupyter==1.0.0
 nwbwidgets==0.5.1
+natsort==7.1.1


### PR DESCRIPTION
Small util function for use in the SpikeInterface pipeline for automatically formatting a Neuralynx extractor similar to how `nwb-conversion-tools` does it. Just cleans up the code for a couple of cells to make it look much nicer.